### PR TITLE
refactor!: remove using of Arc in extractors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-    pull_request:
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Github Actions: Add CI pipeline
 
 ### Changed
+- Breaking change(!): remove Arc usage in `AuthoritiesExtractor` [#1](https://github.com/DDtKey/actix-web-grants/pull/1)
 
 ## [v0.1.6] - 2021-01-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2021-xx-xx
 ### Added
+
+### Changed
+
+## [v1.0.0] - 2021-01-18
+### Added
 - Github Actions: Add CI pipeline
 
 ### Changed
@@ -17,3 +22,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [v0.1.6]: https://crates.io/crates/actix-web-grants/0.1.6
+[v1.0.0]: https://crates.io/crates/actix-web-grants/1.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-grants"
-version = "0.1.6"
+version = "1.0.0"
 authors = ["DDtKey <ddttkey@gmail.com>"]
 description = "Extension for `actix-web` to validate user authorities"
 repository = "https://github.com/DDtKey/actix-web-grants"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ async fn macro_secured() -> HttpResponse {
 use actix_web_grants::{AuthorityGuard, GrantsMiddleware};
 
 App::new()
-    .wrap(GrantsMiddleware::fn_extractor(extract))
+    .wrap(GrantsMiddleware::with_extractor(extract))
     .service(web::resource("/admin")
             .to(|| async { HttpResponse::Ok().finish() })
             .guard(AuthorityGuard::new("ROLE_ADMIN".to_string())))

--- a/examples/base_example.rs
+++ b/examples/base_example.rs
@@ -10,13 +10,13 @@ const OTHER_RESPONSE: &str = "Hello!";
 
 #[get("/admin")]
 #[has_authorities("ROLE_ADMIN")]
-/// An example of protection via `proc-macro`
+// An example of protection via `proc-macro`
 async fn macro_secured() -> HttpResponse {
     HttpResponse::Ok().body(ADMIN_RESPONSE)
 }
 
 #[get("/")]
-/// An example of programmable protection
+// An example of programmable protection
 async fn manual_secure(details: AuthDetails) -> HttpResponse {
     if details.has_authority(ROLE_ADMIN) {
         return HttpResponse::Ok().body(ADMIN_RESPONSE);
@@ -25,7 +25,7 @@ async fn manual_secure(details: AuthDetails) -> HttpResponse {
 }
 
 #[actix_web::main]
-/// Sample application with grant protection based on extracting by your custom function
+// Sample application with grant protection based on extracting by your custom function
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
         let auth = GrantsMiddleware::with_extractor(extract);

--- a/examples/base_example.rs
+++ b/examples/base_example.rs
@@ -3,7 +3,6 @@ use actix_web::{get, middleware, web, App, Error, HttpResponse, HttpServer};
 
 use actix_web_grants::authorities::{AuthDetails, AuthoritiesCheck};
 use actix_web_grants::{proc_macro::has_authorities, AuthorityGuard, GrantsMiddleware};
-use std::sync::Arc;
 
 const ROLE_ADMIN: &str = "ROLE_ADMIN";
 const ADMIN_RESPONSE: &str = "Hello Admin!";
@@ -29,7 +28,7 @@ async fn manual_secure(details: AuthDetails) -> HttpResponse {
 /// Sample application with grant protection based on extracting by your custom function
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
-        let auth = GrantsMiddleware::fn_extractor(extract);
+        let auth = GrantsMiddleware::with_extractor(extract);
         App::new()
             .wrap(middleware::Logger::default())
             .wrap(auth)
@@ -48,7 +47,7 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 
-async fn extract(_req: Arc<ServiceRequest>) -> Result<Vec<String>, Error> {
+async fn extract(_req: &ServiceRequest) -> Result<Vec<String>, Error> {
     // Here is a place for your code to get user authorities/grants/permissions from a request
     // For example from a token or database
 

--- a/examples/integration-httpauth.rs
+++ b/examples/integration-httpauth.rs
@@ -31,12 +31,12 @@ async fn main() -> std::io::Result<()> {
 
 #[get("/admin")]
 #[has_authorities("ROLE_ADMIN")]
-/// For the `ADMIN` - endpoint will give the HTTP status 200, otherwise - 403
-/// You can check via cURL:
-/// ```sh
-/// curl --location --request GET 'http://localhost:8080/admin' \
+// For the `ADMIN` - endpoint will give the HTTP status 200, otherwise - 403
+// You can check via cURL:
+// ```sh
+// curl --location --request GET 'http://localhost:8080/admin' \
 // --header 'Authorization: Bearer ROLE_ADMIN'
-/// ```
+// ```
 async fn admin_secured() -> HttpResponse {
     HttpResponse::Ok().finish()
 }
@@ -44,11 +44,11 @@ async fn admin_secured() -> HttpResponse {
 #[get("/manager")]
 #[has_any_role("ADMIN", "MANAGER")]
 // For the `ADMIN` or `MANAGER` - endpoint will give the HTTP status 200, otherwise - 403
-/// You can check via cURL:
-/// ```sh
-/// curl --location --request GET 'http://localhost:8080/manager' \
+// You can check via cURL:
+// ```sh
+// curl --location --request GET 'http://localhost:8080/manager' \
 // --header 'Authorization: Bearer ROLE_MANAGER'
-/// ```
+// ```
 async fn manager_secured() -> HttpResponse {
     HttpResponse::Ok().finish()
 }

--- a/src/guards.rs
+++ b/src/guards.rs
@@ -13,14 +13,14 @@ use actix_web::guard::Guard;
 /// fn main() {
 ///     HttpServer::new(|| {
 ///         App::new()
-///             .wrap(GrantsMiddleware::fn_extractor(extract))
+///             .wrap(GrantsMiddleware::with_extractor(extract))
 ///             .service(web::resource("/admin")
 ///                     .to(|| async { HttpResponse::Ok().finish() })
 ///                     .guard(AuthorityGuard::new("ROLE_ADMIN".to_string())))
 ///     });
 /// }
 ///
-/// async fn extract(_req: Arc<ServiceRequest>) -> Result<Vec<String>, Error> {
+/// async fn extract(_req: &ServiceRequest) -> Result<Vec<String>, Error> {
 ///    // Here is a place for your code to get user authorities/grants/permissions from a request
 ///    // For example from a token or database
 ///

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,7 +1,6 @@
 use crate::authorities::AttachAuthorities;
-use crate::authorities::{AuthoritiesExtractor, FnAuthoritiesExtractor};
+use crate::authorities::AuthoritiesExtractor;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
-use actix_web::error::ErrorInternalServerError;
 use actix_web::Error;
 use std::cell::RefCell;
 use std::future::{self, Future, Ready};
@@ -20,18 +19,17 @@ use std::task::{Context, Poll};
 ///
 /// use actix_web_grants::authorities::{AuthDetails, AuthoritiesCheck};
 /// use actix_web_grants::{proc_macro::has_authorities, GrantsMiddleware};
-/// use std::sync::Arc;
 ///
 /// fn main() {
 ///     HttpServer::new(|| {
-///         let auth = GrantsMiddleware::fn_extractor(extract);
+///         let auth = GrantsMiddleware::with_extractor(extract);
 ///         App::new()
 ///             .wrap(auth)
 ///             .service(you_service)
 ///     });
 /// }
 ///
-/// async fn extract(_req: Arc<ServiceRequest>) -> Result<Vec<String>, Error> {
+/// async fn extract(_req: &ServiceRequest) -> Result<Vec<String>, Error> {
 ///    // Here is a place for your code to get user authorities/grants/permissions from a request
 ///    // For example from a token or database
 ///
@@ -48,15 +46,33 @@ use std::task::{Context, Poll};
 /// ```
 pub struct GrantsMiddleware<T>
 where
-    T: AuthoritiesExtractor,
+    for<'a> T: AuthoritiesExtractor<'a>,
 {
     extractor: Arc<T>,
 }
 
 impl<T> GrantsMiddleware<T>
 where
-    T: AuthoritiesExtractor,
+    for<'a> T: AuthoritiesExtractor<'a>,
 {
+    /// Create middleware by [`AuthoritiesExtractor`].
+    ///
+    /// You can use a built-in implementation for `async fn` with a suitable signature (see example below).
+    /// Or you can define your own implementation of trait.
+    ///
+    /// # Example of function with implementation of [`AuthoritiesExtractor`]
+    /// ```
+    /// use actix_web::dev::ServiceRequest;
+    /// use actix_web::Error;
+    ///
+    /// async fn extract(_req: &ServiceRequest) -> Result<Vec<String>, Error> {
+    ///     // Here is a place for your code to get user authorities/grants/permissions from a request
+    ///      // For example from a token or database
+    ///     Ok(vec!["WRITE_ACCESS".to_string()])
+    /// }
+    /// ```
+    ///
+    ///[`AuthoritiesExtractor`]: actix_web_grants::authoritites::AuthoritiesExtractor
     pub fn with_extractor(extractor: T) -> GrantsMiddleware<T> {
         GrantsMiddleware {
             extractor: Arc::new(extractor),
@@ -64,21 +80,10 @@ where
     }
 }
 
-impl<F, O> GrantsMiddleware<FnAuthoritiesExtractor<F, O>>
-where
-    F: Fn(Arc<ServiceRequest>) -> O,
-    O: Future<Output = Result<Vec<String>, Error>>,
-{
-    pub fn fn_extractor(extract_fn: F) -> GrantsMiddleware<FnAuthoritiesExtractor<F, O>> {
-        let extractor = FnAuthoritiesExtractor::new(extract_fn);
-        Self::with_extractor(extractor)
-    }
-}
-
 impl<S, B, T> Transform<S> for GrantsMiddleware<T>
 where
     S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
-    T: AuthoritiesExtractor + 'static,
+    for<'a> T: AuthoritiesExtractor<'a> + 'static,
 {
     type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
@@ -96,7 +101,7 @@ where
 
 pub struct GrantsService<S, T>
 where
-    T: AuthoritiesExtractor + 'static,
+    for<'a> T: AuthoritiesExtractor<'a> + 'static,
 {
     service: Rc<RefCell<S>>,
     extractor: Arc<T>,
@@ -105,7 +110,7 @@ where
 impl<S, B, T> Service for GrantsService<S, T>
 where
     S: Service<Request = ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
-    T: AuthoritiesExtractor,
+    for<'a> T: AuthoritiesExtractor<'a>,
 {
     type Request = ServiceRequest;
     type Response = ServiceResponse<B>;
@@ -118,14 +123,12 @@ where
 
     fn call(&mut self, req: Self::Request) -> Self::Future {
         let service = Rc::clone(&self.service);
-        let req = Arc::new(req);
-        let authorities_fut = Arc::clone(&self.extractor).extract(req.clone());
+        let extractor = Arc::clone(&self.extractor);
 
         Box::pin(async move {
-            let authorities: Vec<String> = authorities_fut.await?;
+            let authorities: Vec<String> = extractor.extract(&req).await?;
             req.attach(authorities);
-            let req = Arc::try_unwrap(req)
-                .map_err(|_| ErrorInternalServerError("Request processing error"))?;
+
             let fut = service.borrow_mut().call(req);
             fut.await
         })

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -72,7 +72,7 @@ where
     /// }
     /// ```
     ///
-    ///[`AuthoritiesExtractor`]: actix_web_grants::authorities::AuthoritiesExtractor
+    ///[`AuthoritiesExtractor`]: crate::authorities::AuthoritiesExtractor
     pub fn with_extractor(extractor: T) -> GrantsMiddleware<T> {
         GrantsMiddleware {
             extractor: Arc::new(extractor),

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -72,7 +72,7 @@ where
     /// }
     /// ```
     ///
-    ///[`AuthoritiesExtractor`]: actix_web_grants::authoritites::AuthoritiesExtractor
+    ///[`AuthoritiesExtractor`]: actix_web_grants::authorities::AuthoritiesExtractor
     pub fn with_extractor(extractor: T) -> GrantsMiddleware<T> {
         GrantsMiddleware {
             extractor: Arc::new(extractor),

--- a/tests/authorities_check/guard_check.rs
+++ b/tests/authorities_check/guard_check.rs
@@ -17,7 +17,7 @@ async fn test_guard() {
 async fn get_user_response(uri: &str, role: &str) -> ServiceResponse {
     let mut app = test::init_service(
         App::new()
-            .wrap(GrantsMiddleware::fn_extractor(common::extract))
+            .wrap(GrantsMiddleware::with_extractor(common::extract))
             .service(
                 web::resource("/admin")
                     .to(|| async { HttpResponse::Ok().finish() })

--- a/tests/authorities_check/manual_check.rs
+++ b/tests/authorities_check/manual_check.rs
@@ -46,7 +46,7 @@ async fn test_forbidden() {
 async fn get_user_response(uri: &str, role: &str) -> ServiceResponse {
     let mut app = test::init_service(
         App::new()
-            .wrap(GrantsMiddleware::fn_extractor(common::extract))
+            .wrap(GrantsMiddleware::with_extractor(common::extract))
             .service(different_body)
             .service(only_admin),
     )

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -2,12 +2,11 @@ use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::error::ErrorUnauthorized;
 use actix_web::http::{header::AUTHORIZATION, HeaderValue};
 use actix_web::{test, Error};
-use std::sync::Arc;
 
 pub const ROLE_ADMIN: &str = "ROLE_ADMIN";
 pub const ROLE_MANAGER: &str = "ROLE_MANAGER";
 
-pub async fn extract(req: Arc<ServiceRequest>) -> Result<Vec<String>, Error> {
+pub async fn extract(req: &ServiceRequest) -> Result<Vec<String>, Error> {
     let auth_header: Option<&str> = req
         .headers()
         .get(AUTHORIZATION)

--- a/tests/proc_macro/different_fn_types.rs
+++ b/tests/proc_macro/different_fn_types.rs
@@ -41,7 +41,7 @@ async fn test_str() {
 async fn get_user_response(uri: &str, role: &str) -> ServiceResponse {
     let mut app = test::init_service(
         App::new()
-            .wrap(GrantsMiddleware::fn_extractor(common::extract))
+            .wrap(GrantsMiddleware::with_extractor(common::extract))
             .service(str_response)
             .service(http_response),
     )


### PR DESCRIPTION
#### Description:
<!-- Thank you for considering to contribute. 
Please provide a description below. -->

**It's a breaking change!**
Removed use of `Arc` in extractors and simplified implementation of `FnAuthoritiesExtractor`.
Through the correct provide of lifetimes (HRTBs)


#### Checklist:
<!-- Don't delete these items! For completed items, change [ ] to [x]. -->

- [x] Tests for the changes have been added (_for bug fixes / features_);
- [x] Docs have been added / updated (_for bug fixes / features_).
- [x] This PR has been added to [CHANGELOG.md](https://github.com/DDtKey/actix-web-grants/blob/main/CHANGELOG.md) (to [Unreleased] section);

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
