### PR TITLE
Wrap proc-macroed function body in closure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ macro-check = ["actix-grants-proc-macro"]
 
 [dependencies]
 actix-web = { version = "3.0.0", default-features = false}
-actix-grants-proc-macro = { version = "1", optional = true }
+actix-grants-proc-macro = { path = "./proc-macro", version = "1", optional = true }
 
 [dev-dependencies]
 actix-rt = "2"

--- a/proc-macro/src/expand.rs
+++ b/proc-macro/src/expand.rs
@@ -68,7 +68,8 @@ impl ToTokens for HasPermissions {
             ) -> actix_web::Either<#fn_output, actix_web::HttpResponse> {
                 use actix_web_grants::permissions::{PermissionsCheck, RolesCheck};
                 if _auth_details_.#check_fn(vec![#args]) {
-                    actix_web::Either::A(#func_block)
+                    let f = || async { #func_block };
+                    actix_web::Either::A(f().await)
                 } else {
                     actix_web::Either::B(actix_web::HttpResponse::Forbidden().finish())
                 }

--- a/tests/proc_macro/different_fn_types.rs
+++ b/tests/proc_macro/different_fn_types.rs
@@ -17,6 +17,20 @@ async fn str_response() -> &'static str {
     "Hi!"
 }
 
+#[get("/return")]
+#[has_roles("ADMIN")]
+async fn return_response() -> &'static str {
+    return "Hi!"
+}
+
+#[get("/result")]
+#[has_roles("ADMIN")]
+async fn result_response() -> Result<&'static str, ()> {
+    Err(())?;
+    
+    panic!()
+}
+
 #[actix_rt::test]
 async fn test_http_response() {
     let test_admin = get_user_response("/http_response", ROLE_ADMIN).await;
@@ -42,6 +56,8 @@ async fn get_user_response(uri: &str, role: &str) -> ServiceResponse {
     let mut app = test::init_service(
         App::new()
             .wrap(GrantsMiddleware::with_extractor(common::extract))
+            .service(result_response)
+            .service(return_response)
             .service(str_response)
             .service(http_response),
     )

--- a/tests/proc_macro/different_fn_types.rs
+++ b/tests/proc_macro/different_fn_types.rs
@@ -20,14 +20,14 @@ async fn str_response() -> &'static str {
 #[get("/return")]
 #[has_roles("ADMIN")]
 async fn return_response() -> &'static str {
-    return "Hi!"
+    return "Hi!";
 }
 
 #[get("/result")]
 #[has_roles("ADMIN")]
 async fn result_response() -> Result<&'static str, ()> {
     Err(())?;
-    
+
     panic!()
 }
 


### PR DESCRIPTION
#### Description:
<!-- Thank you for considering to contribute. 
Please provide a description below. -->
Make ?-operator and early returning work as expected in functions with the `#[has_permissions("foo")]` attribute. This simply wraps the function body in a closure with an async block whis is immediately called and awaited. I believe that probably makes this a breaking change?

It should probably be noted that I have never played with the implementation of proc macros before...

#### Checklist:
<!-- Don't delete these items! For completed items, change [ ] to [x]. -->

- [x] Tests for the changes have been added (_for bug fixes / features_);
- [ ] Docs have been added / updated (_for bug fixes / features_).
- [ ] This PR has been added to [CHANGELOG.md](https://github.com/DDtKey/actix-web-grants/blob/main/CHANGELOG.md) (to [Unreleased] section);

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #3
