### PR TITLE
feat: allow extractor to receive mutable requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2021-xx-xx
 ### Added
+- Allow extractor to receive mutable requests [#17](https://github.com/DDtKey/actix-web-grants/pull/17)
 
 ### Changed
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -3,6 +3,7 @@ use crate::permissions::PermissionsExtractor;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::Error;
 use std::future::{self, Future, Ready};
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
@@ -42,16 +43,17 @@ use std::task::{Context, Poll};
 ///     HttpResponse::Ok().finish()
 /// }
 /// ```
-pub struct GrantsMiddleware<T>
+pub struct GrantsMiddleware<T, Req>
 where
-    for<'a> T: PermissionsExtractor<'a>,
+    for<'a> T: PermissionsExtractor<'a, Req>,
 {
     extractor: Rc<T>,
+    phantom_req: PhantomData<Req>,
 }
 
-impl<T> GrantsMiddleware<T>
+impl<T, Req> GrantsMiddleware<T, Req>
 where
-    for<'a> T: PermissionsExtractor<'a>,
+    for<'a> T: PermissionsExtractor<'a, Req>,
 {
     /// Create middleware by [`PermissionsExtractor`].
     ///
@@ -71,21 +73,22 @@ where
     /// ```
     ///
     ///[`PermissionsExtractor`]: crate::permissions::PermissionsExtractor
-    pub fn with_extractor(extractor: T) -> GrantsMiddleware<T> {
+    pub fn with_extractor(extractor: T) -> GrantsMiddleware<T, Req> {
         GrantsMiddleware {
             extractor: Rc::new(extractor),
+            phantom_req: PhantomData,
         }
     }
 }
 
-impl<S, B, T> Transform<S, ServiceRequest> for GrantsMiddleware<T>
+impl<S, B, T, Req> Transform<S, ServiceRequest> for GrantsMiddleware<T, Req>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
-    for<'a> T: PermissionsExtractor<'a> + 'static,
+    for<'a> T: PermissionsExtractor<'a, Req> + 'static,
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
-    type Transform = GrantsService<S, T>;
+    type Transform = GrantsService<S, T, Req>;
     type InitError = ();
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
@@ -93,22 +96,24 @@ where
         future::ready(Ok(GrantsService {
             service: Rc::new(service),
             extractor: self.extractor.clone(),
+            phantom_req: PhantomData,
         }))
     }
 }
 
-pub struct GrantsService<S, T>
+pub struct GrantsService<S, T, Req>
 where
-    for<'a> T: PermissionsExtractor<'a> + 'static,
+    for<'a> T: PermissionsExtractor<'a, Req> + 'static,
 {
     service: Rc<S>,
     extractor: Rc<T>,
+    phantom_req: PhantomData<Req>,
 }
 
-impl<S, B, T> Service<ServiceRequest> for GrantsService<S, T>
+impl<S, B, T, Req> Service<ServiceRequest> for GrantsService<S, T, Req>
 where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
-    for<'a> T: PermissionsExtractor<'a>,
+    for<'a> T: PermissionsExtractor<'a, Req>,
 {
     type Response = ServiceResponse<B>;
     type Error = Error;
@@ -118,12 +123,12 @@ where
         self.service.poll_ready(cx)
     }
 
-    fn call(&self, req: ServiceRequest) -> Self::Future {
+    fn call(&self, mut req: ServiceRequest) -> Self::Future {
         let service = Rc::clone(&self.service);
         let extractor = Rc::clone(&self.extractor);
 
         Box::pin(async move {
-            let permissions: Vec<String> = extractor.extract(&req).await?;
+            let permissions: Vec<String> = extractor.extract(&mut req).await?;
             req.attach(permissions);
 
             service.call(req).await

--- a/src/permissions/extractors.rs
+++ b/src/permissions/extractors.rs
@@ -2,20 +2,32 @@ use actix_web::dev::ServiceRequest;
 use actix_web::Error;
 use std::future::Future;
 
-pub trait PermissionsExtractor<'a> {
+pub trait PermissionsExtractor<'a, Req> {
     type Future: Future<Output = Result<Vec<String>, Error>>;
 
-    fn extract(&self, request: &'a ServiceRequest) -> Self::Future;
+    fn extract(&self, request: &'a mut ServiceRequest) -> Self::Future;
 }
 
-impl<'a, F, O> PermissionsExtractor<'a> for F
+impl<'a, F, O> PermissionsExtractor<'a, &ServiceRequest> for F
 where
     F: Fn(&'a ServiceRequest) -> O,
     O: Future<Output = Result<Vec<String>, Error>>,
 {
     type Future = O;
 
-    fn extract(&self, req: &'a ServiceRequest) -> Self::Future {
+    fn extract(&self, req: &'a mut ServiceRequest) -> Self::Future {
+        (self)(req)
+    }
+}
+
+impl<'a, F, O> PermissionsExtractor<'a, &mut ServiceRequest> for F
+where
+    F: Fn(&'a mut ServiceRequest) -> O,
+    O: Future<Output = Result<Vec<String>, Error>>,
+{
+    type Future = O;
+
+    fn extract(&self, req: &'a mut ServiceRequest) -> Self::Future {
         (self)(req)
     }
 }
@@ -23,6 +35,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::dev::ServiceRequest;
     use actix_web::test;
 
     async fn extract(_req: &ServiceRequest) -> Result<Vec<String>, Error> {
@@ -31,8 +44,23 @@ mod tests {
 
     #[actix_rt::test]
     async fn test_fn_extractor_impl() {
-        let req = test::TestRequest::get().to_srv_request();
-        let permissions = extract.extract(&req).await;
+        let mut req = test::TestRequest::get().to_srv_request();
+        let permissions = extract.extract(&mut req).await;
+
+        permissions
+            .unwrap()
+            .iter()
+            .for_each(|perm| assert_eq!("TEST_PERMISSION", perm.as_str()));
+    }
+
+    async fn mut_extract(_req: &mut ServiceRequest) -> Result<Vec<String>, Error> {
+        Ok(vec!["TEST_PERMISSION".to_string()])
+    }
+
+    #[actix_rt::test]
+    async fn test_fn_mut_extractor_impl() {
+        let mut req = test::TestRequest::get().to_srv_request();
+        let permissions = mut_extract.extract(&mut req).await;
 
         permissions
             .unwrap()


### PR DESCRIPTION
#### Description:
<!-- Thank you for considering to contribute. 
Please provide a description below. -->
These are backward compatible changes to allow the permission extractor to receive mutable `ServiceRequest`.

#### Checklist:
<!-- Don't delete these items! For completed items, change [ ] to [x]. -->

- [X] Tests for the changes have been added (_for bug fixes / features_);
- [ ] Docs have been added / updated (_for bug fixes / features_).
- [X] This PR has been added to [CHANGELOG.md](https://github.com/DDtKey/actix-web-grants/blob/main/CHANGELOG.md) (to [Unreleased] section);

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #16
