### PR TITLE
Remove unused `Config` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-
+- Remove unused `Config` type [#20](https://github.com/DDtKey/actix-web-grants/pull/20)
 
 ## [v3.0.0-beta.3] - 2021-10-11
 ### Added

--- a/src/permissions/mod.rs
+++ b/src/permissions/mod.rs
@@ -89,7 +89,6 @@ impl RolesCheck for AuthDetails {
 impl FromRequest for AuthDetails {
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self, Error>>>>;
-    type Config = ();
 
     fn from_request(req: &HttpRequest, _payload: &mut Payload<PayloadStream>) -> Self::Future {
         let req = req.clone();


### PR DESCRIPTION
#### Description:
<!-- Thank you for considering to contribute. 
Please provide a description below. -->
Fix the following error:
```
error[E0437]: type `Config` is not a member of trait `FromRequest`
  --> src/permissions/mod.rs:92:5
   |
92 |     type Config = ();
   |     ^^^^^^^^^^^^^^^^^ not a member of trait `FromRequest`

For more information about this error, try `rustc --explain E0437`.
error: could not compile `actix-web-grants` due to previous error
```

#### Checklist:
<!-- Don't delete these items! For completed items, change [ ] to [x]. -->

- [ ] Tests for the changes have been added (_for bug fixes / features_);
- [ ] Docs have been added / updated (_for bug fixes / features_).
- [x] This PR has been added to [CHANGELOG.md](https://github.com/DDtKey/actix-web-grants/blob/main/CHANGELOG.md) (to [Unreleased] section);

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
