### PR TITLE
chore: Bump actix-web version to 4.0 (stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v3.0.0] - 22-04-02
 ### Added
-- `actix-web: 4.0.1` support []
+- `actix-web: 4.0.1` support [#30]
 
 
 ## [v3.0.0-beta.6] - 2022-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [v3.0.0] - 22-04-02
+### Added
+- `actix-web: 4.0.1` support []
+
 
 ## [v3.0.0-beta.6] - 2022-01-08
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-web-grants"
-version = "3.0.0-beta.6"
+version = "3.0.0"
 authors = ["DDtKey <ddttkey@gmail.com>"]
 description = "Extension for `actix-web` to validate user permissions"
 repository = "https://github.com/DDtKey/actix-web-grants"
@@ -20,9 +20,9 @@ default = ["macro-check"]
 macro-check = ["actix-grants-proc-macro"]
 
 [dependencies]
-actix-web = { version = "4.0.0-beta.19", default-features = false }
-actix-grants-proc-macro = { path = "./proc-macro", version = "2.0.0-beta.6", optional = true }
+actix-web = { version = "4.0", default-features = false, features = ["macros"] }
+actix-grants-proc-macro = { path = "./proc-macro", version = "2.0.0", optional = true }
 
 [dev-dependencies]
 actix-rt = "2"
-serde = {version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/proc-macro/Cargo.toml
+++ b/proc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-grants-proc-macro"
-version = "2.0.0-beta.6"
+version = "2.0.0"
 authors = ["DDtKey <ddttkey@gmail.com>"]
 description = "A proc-macro way to validate user permissions for `actix-web-grants` crate."
 repository = "https://github.com/DDtKey/actix-web-grants"
@@ -19,5 +19,5 @@ proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["full", "derive", "extra-traits"] }
 
 [dev-dependencies]
-actix-web = { version = "4.0.0-beta.19", default-features = false }
+actix-web = { version = "4.0", default-features = false }
 actix-web-grants =  { path = "../" }


### PR DESCRIPTION
#### Description:
Bump Actix Web dependency to stable 4.0 and add `macros` feature to support `get`, ….

Closes #31 

#### Checklist:

- [x] Tests for the changes have been added (_for bug fixes / features_);
- [x] Docs have been added / updated (_for bug fixes / features_).
- [x] This PR has been added to [CHANGELOG.md](https://github.com/DDtKey/actix-web-grants/blob/main/CHANGELOG.md) (to [Unreleased] section);
